### PR TITLE
[Fix] Generation was failed when some case

### DIFF
--- a/DocfxToAstro/MarkdownGenerator.cs
+++ b/DocfxToAstro/MarkdownGenerator.cs
@@ -248,7 +248,7 @@ internal sealed partial class MarkdownGenerator
 			AppendMethods(in type, ref sb, in cancellationToken);
 			AppendEvents(in type, ref sb, in cancellationToken);
 
-			string path = Path.Combine(baseOutputFolder, ZString.Concat(type.FullName, ".md"));
+			string path = Path.Combine(baseOutputFolder, ZString.Concat(type.Uid.Replace("`", "-"), ".md"));
 
 			sb.WriteToFile(path);
 

--- a/DocfxToAstro/Models/TypeDocumentation.cs
+++ b/DocfxToAstro/Models/TypeDocumentation.cs
@@ -8,13 +8,13 @@ namespace DocfxToAstro.Models;
 
 public sealed class TypeDocumentation
 {
-	private readonly string uid;
 	private readonly List<TypeDocumentation> constructors = new List<TypeDocumentation>();
 	private readonly List<TypeDocumentation> fields = new List<TypeDocumentation>();
 	private readonly List<TypeDocumentation> properties = new List<TypeDocumentation>();
 	private readonly List<TypeDocumentation> methods = new List<TypeDocumentation>();
 	private readonly List<TypeDocumentation> events = new List<TypeDocumentation>();
 
+	public string Uid { get; }
 	public string Name { get; }
 	public string FullName { get; }
 	public ItemType Type { get; }
@@ -58,7 +58,7 @@ public sealed class TypeDocumentation
 
 	public TypeDocumentation(Item item, ReferenceCollection references)
 	{
-		uid = item.Uid!;
+		Uid = item.Uid!;
 
 		Name = item.Name!;
 		FullName = item.FullName!;
@@ -87,7 +87,7 @@ public sealed class TypeDocumentation
 		for (int i = 0; i < items.Count; i++)
 		{
 			// Skip if the item is not a child of this type
-			if (items[i].Parent != uid)
+			if (items[i].Parent != Uid)
 			{
 				continue;
 			}

--- a/DocfxToAstro/Models/Yaml/Reference.cs
+++ b/DocfxToAstro/Models/Yaml/Reference.cs
@@ -13,8 +13,9 @@ public partial struct Reference
 		get { return name;}
 		set
 		{
-			name = value.Replace("<", "\\<").Replace(">", "\\>");
-		} }
+			name = value?.Replace("<", "\\<").Replace(">", "\\>") ?? string.Empty;
+		}
+	}
 	
 	public string Href { get; set; }
 }


### PR DESCRIPTION
# Fail case
1. When some `class` or `method` signature has generic parameters.
2. When a `name` hasn't provided from docfx.

# Fix
1. Use `uid` as a filename.
2. Add nullish coalescing op.