### PR TITLE
Fix Edit page links & incorrect remarks heading levels for fields

### DIFF
--- a/DocfxToAstro/Helpers/GitUtility.cs
+++ b/DocfxToAstro/Helpers/GitUtility.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace DocfxToAstro.Helpers;
+
+// Taken from:
+// https://github.com/dotnet/docfx/blob/c4447a95/src/Docfx.Common/Git/GitUtility.cs
+// Copyright (c) .NET Foundation and Contributors
+// Licensed under the MIT license.
+
+public readonly record struct GitSource(string Repo, string Branch, string Path, int Line);
+
+public static partial class GitUtility
+{
+	public static string? GetSourceUrl(GitSource source)
+	{
+		ReadOnlySpan<char> repo = source.Repo.StartsWith("git") ? GitUrlToHttps(source.Repo) : source.Repo;
+		repo = repo.TrimEnd('/').TrimEnd(".git");
+
+		if (!Uri.TryCreate(repo.ToString(), UriKind.Absolute, out var url))
+			return null;
+
+		var path = source.Path.Replace('\\', '/');
+
+		var sourceUrl = url.Host switch
+		{
+			"github.com" => $"https://github.com{url.AbsolutePath}/blob/{source.Branch}/{path}{(source.Line > 0 ? $"#L{source.Line}" : null)}",
+			"bitbucket.org" => $"https://bitbucket.org{url.AbsolutePath}/src/{source.Branch}/{path}{(source.Line > 0 ? $"#lines-{source.Line}" : null)}",
+			_ when url.Host.EndsWith(".visualstudio.com") || url.Host == "dev.azure.com" =>
+				$"https://{url.Host}{url.AbsolutePath}?path={path}&version={(IsCommit(source.Branch) ? "GC" : "GB")}{source.Branch}{(source.Line > 0 ? $"&line={source.Line}" : null)}",
+			_ => null,
+		};
+
+		if (sourceUrl == null)
+			return null;
+
+		return ResolveDocfxSourceRepoUrl(sourceUrl);
+
+		static bool IsCommit(string branch)
+		{
+			return branch.Length == 40 && branch.All(char.IsLetterOrDigit);
+		}
+
+		static string GitUrlToHttps(string url)
+		{
+			var pos = url.IndexOf('@');
+			if (pos == -1) return url;
+			return $"https://{url.Substring(pos + 1).Replace(":[0-9]+", "").Replace(':', '/')}";
+		}
+	}
+
+	/// <summary>
+	/// Rewrite path if `DOCFX_SOURCE_REPOSITORY_URL` environment variable is specified.
+	/// </summary>
+	private static string ResolveDocfxSourceRepoUrl(string originalUrl)
+	{
+		var docfxSourceRepoUrl = Environment.GetEnvironmentVariable("DOCFX_SOURCE_REPOSITORY_URL");
+		if (docfxSourceRepoUrl == null)
+			return originalUrl;
+
+		if (!Uri.TryCreate(originalUrl, UriKind.Absolute, out var parsedOriginalUrl)
+		 || !Uri.TryCreate(docfxSourceRepoUrl, UriKind.Absolute, out var parsedOverrideUrl)
+		 || parsedOriginalUrl.Host != parsedOverrideUrl.Host)
+		{
+			return originalUrl;
+		}
+
+		// Parse value that defined with `{orgName}/{repoName}` format.
+		var parts = parsedOverrideUrl.LocalPath.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+		if (parts.Length < 2)
+			return originalUrl;
+
+		string orgName = parts[0];
+		string repoName = parts[1];
+
+		switch (parsedOriginalUrl.Host)
+		{
+			case "github.com":
+			case "bitbucket.org":
+			case "dev.azure.com":
+				{
+					// Replace `/{orgName}/{repoName}` and remove `.git` suffix.
+					var builder = new UriBuilder(parsedOriginalUrl);
+					builder.Path = OrgRepoRegex().Replace(builder.Path.TrimEnd(".git").ToString(), $"/{orgName}/{repoName}");
+					return builder.Uri.ToString();
+				}
+
+			// Currently other URL formats are not supported (e.g. visualstudio.com, GitHub Enterprise Server)
+			default:
+				return originalUrl;
+		}
+	}
+
+	[GeneratedRegex("^/[^/]+/[^/]+")]
+	private static partial Regex OrgRepoRegex();
+}

--- a/DocfxToAstro/MarkdownGenerator.cs
+++ b/DocfxToAstro/MarkdownGenerator.cs
@@ -592,7 +592,7 @@ internal sealed partial class MarkdownGenerator
 			sb.AppendLine();
 		}
 
-		WriteRemarks(in type, ref sb, in cancellationToken);
+		WriteRemarks(in type, ref sb, in cancellationToken, "##");
 
 		sb.AppendLine();
 	}
@@ -633,7 +633,7 @@ internal sealed partial class MarkdownGenerator
 				sb.AppendLine("```");
 			}
 
-			WriteRemarks(in field, ref sb, in cancellationToken);
+			WriteRemarks(in field, ref sb, in cancellationToken, "####");
 
 			sb.AppendLine();
 		}
@@ -841,7 +841,7 @@ internal sealed partial class MarkdownGenerator
 		}
 	}
 
-	private static void WriteRemarks(in TypeDocumentation type, ref Utf16ValueStringBuilder sb, in CancellationToken cancellationToken, string header = "##")
+	private static void WriteRemarks(in TypeDocumentation type, ref Utf16ValueStringBuilder sb, in CancellationToken cancellationToken, string header)
 	{
 		cancellationToken.ThrowIfCancellationRequested();
 

--- a/DocfxToAstro/MarkdownGenerator.cs
+++ b/DocfxToAstro/MarkdownGenerator.cs
@@ -38,6 +38,7 @@ internal sealed partial class MarkdownGenerator
 			indexBuilder.AppendLine("title: API Reference");
 			indexBuilder.AppendLine("sidebar:");
 			indexBuilder.AppendLine("  hidden: true");
+			indexBuilder.AppendLine("editUrl: false");
 			indexBuilder.AppendLine("---");
 			indexBuilder.AppendLine();
 
@@ -112,6 +113,7 @@ internal sealed partial class MarkdownGenerator
 			indexBuilder.AppendLine("title: API Reference");
 			indexBuilder.AppendLine("sidebar:");
 			indexBuilder.AppendLine("  hidden: true");
+			indexBuilder.AppendLine("editUrl: false");
 			indexBuilder.AppendLine("---");
 			indexBuilder.AppendLine();
 
@@ -249,6 +251,7 @@ internal sealed partial class MarkdownGenerator
 			indexBuilder.AppendLine(assembly.Name.ToLowerInvariant());
 			indexBuilder.AppendLine("sidebar:");
 			indexBuilder.AppendLine("  order: 0");
+			indexBuilder.AppendLine("editUrl: false");
 			indexBuilder.AppendLine("---");
 
 			List<TypeDocumentation> classes = assembly.Types.Where(static x => x.Type == ItemType.Class).ToList();
@@ -352,6 +355,7 @@ internal sealed partial class MarkdownGenerator
 			indexBuilder.AppendLine(namespaceDoc.Name.ToLowerInvariant());
 			indexBuilder.AppendLine("sidebar:");
 			indexBuilder.AppendLine("  order: 0");
+			indexBuilder.AppendLine("editUrl: false");
 			indexBuilder.AppendLine("---");
 
 			List<TypeDocumentation> classes = namespaceDoc.Types.Where(static x => x.Type == ItemType.Class).ToList();
@@ -507,6 +511,13 @@ internal sealed partial class MarkdownGenerator
 		sb.AppendLine("sidebar:");
 		sb.Append("  label: ");
 		sb.AppendLine(root.Name);
+
+		sb.Append("editUrl: ");
+		if (root.Source?.TryGetSourceUrl(out var sourceUrl) ?? false)
+			sb.AppendLine(sourceUrl);
+		else
+			sb.AppendLine("false");
+
 		sb.AppendLine("---");
 	}
 

--- a/DocfxToAstro/Models/TypeDocumentation.cs
+++ b/DocfxToAstro/Models/TypeDocumentation.cs
@@ -19,6 +19,7 @@ public sealed class TypeDocumentation
 	public string MarkdownName { get; }
 	public string FullName { get; }
 	public ItemType Type { get; }
+	public ItemSource? Source { get; }
 	public string? Summary { get; }
 	public Link Link { get; }
 	public string? Syntax { get; }
@@ -65,6 +66,7 @@ public sealed class TypeDocumentation
 		MarkdownName = Name.Replace("<", @"\<");
 		FullName = item.FullName!;
 		Type = item.Type;
+		Source = item.Source;
 		Summary = Formatters.FormatSummary(item.Summary, references);
 		Remarks = Formatters.FormatSummary(item.Remarks, references);
 		if (item.Syntax != null && !string.IsNullOrWhiteSpace(item.Syntax.Content))

--- a/DocfxToAstro/Models/Yaml/Item.cs
+++ b/DocfxToAstro/Models/Yaml/Item.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using DocfxToAstro.Helpers;
 using VYaml.Annotations;
 
 namespace DocfxToAstro.Models.Yaml;
@@ -24,6 +26,7 @@ public partial class Item
 	public string[]? Implements { get; private init; }
 	public ExceptionDoc[]? Exceptions { get; private init; }
 	public AttributeDoc[]? Attributes { get; private init; }
+	public ItemSource? Source { get; private init; }
 
 	[YamlIgnore]
 	public ItemType Type
@@ -48,4 +51,27 @@ public partial class Item
 			};
 		}
 	}
+}
+
+[YamlObject]
+public readonly partial struct ItemSource
+{
+	public ItemSourceRemote Remote { get; private init; }
+	public int StartLine { get; private init; }
+
+	public readonly bool TryGetSourceUrl([NotNullWhen(true)] out string? url)
+	{
+		// Note: StartLine + 1 is actually how they do it:
+		// https://github.com/dotnet/docfx/blob/c4447a95/src/Docfx.Dotnet/DotnetApiCatalog.ApiPage.cs#L133
+		url = GitUtility.GetSourceUrl(new(Remote.Repo, Remote.Branch, Remote.Path, StartLine + 1));
+		return url is { };
+	}
+}
+
+[YamlObject]
+public readonly partial struct ItemSourceRemote
+{
+	public string Path { get; private init; }
+	public string Branch { get; private init; }
+	public string Repo { get; private init; }
 }

--- a/DocfxToAstro/Models/Yaml/Root.cs
+++ b/DocfxToAstro/Models/Yaml/Root.cs
@@ -6,6 +6,6 @@ namespace DocfxToAstro.Models.Yaml;
 [YamlObject]
 public partial class Root
 {
-	public List<Item> Items { get; set; }
-	public Reference[] References { get; set; }
+	public required List<Item> Items { get; init; }
+	public required Reference[] References { get; init; }
 }


### PR DESCRIPTION
also resolves nullable warnings for `Root`.

Regarding the edit page links thing, I explained it in the commit *fix: point edit page to source code or disable it*:
> Before it would have pointed to source generated
files which can't be modified directly anyways
even if they existed in the docs repository site.
>
> Techincally this is more like "view source", but
it's almost close enough. Besides, there is no
built-in "view source" button in Starlight.